### PR TITLE
Convert Pod to Deployment. Remove nodePort from Service spec.

### DIFF
--- a/mc-server.yaml
+++ b/mc-server.yaml
@@ -14,49 +14,58 @@ data:
 
 ---
 
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: mc-server
-  labels:
-    app: minecraft
 spec:
-  containers:
-  - name: mc-container
-    image: limingyu007/minecraft-server:1.20.1
-    ports:
-    - containerPort: 25565
-    volumeMounts:
-    - mountPath: /minecraft/world
-      name: mc-data
-      subPath: world
-    - mountPath: /minecraft/eula.txt
-      name: mc-config
-      subPath: eula.txt
-    - mountPath: /minecraft/server.properties
-      name: mc-config
-      subPath: server.properties
-    livenessProbe:
-      tcpSocket:
-        port: 25565
-      initialDelaySeconds: 30
-      periodSeconds: 10
-    startupProbe:
-      tcpSocket:
-        port: 25565
-      initialDelaySeconds: 10
-      periodSeconds: 5
-      failureThreshold: 10
-    resources:
-      requests:
-        memory: "1.5Gi"
-  volumes:
-  - name: mc-data
-    persistentVolumeClaim:
-      claimName: mc-pvc
-  - name: mc-config
-    configMap:
-      name: mc-config
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minecraft
+  template:
+    metadata:
+      labels:
+        app: minecraft
+    spec:
+      containers:
+      - name: mc-container
+        image: limingyu007/minecraft-server:1.20.1
+        ports:
+        - containerPort: 25565
+        volumeMounts:
+        - mountPath: /minecraft/world
+          name: mc-data
+          subPath: world
+        - mountPath: /minecraft/eula.txt
+          name: mc-config
+          subPath: eula.txt
+        - mountPath: /minecraft/server.properties
+          name: mc-config
+          subPath: server.properties
+        livenessProbe:
+          tcpSocket:
+            port: 25565
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        startupProbe:
+          tcpSocket:
+            port: 25565
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 10
+        resources:
+          requests:
+            memory: "1.5Gi"
+      volumes:
+      - name: mc-data
+        persistentVolumeClaim:
+          claimName: mc-pvc
+      - name: mc-config
+        configMap:
+          name: mc-config
 
 ---
 
@@ -84,5 +93,4 @@ spec:
     - protocol: TCP
       port: 25565
       targetPort: 25565
-      nodePort: 32693
   type: NodePort 


### PR DESCRIPTION
Convert Pod to Deployment towards better manageability. The Deployment is configured with a strategy type of "Recreate" and a single replica due to the characteristics of the Minecraft server, where a new instance cannot start if another one is online sharing the same world data.